### PR TITLE
security: add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a workflow-level `permissions: contents: read` block to `ci.yml`
- Follows the principle of least privilege for `GITHUB_TOKEN`
- Resolves CodeQL security alerts #1 and #2 (`actions/missing-workflow-permissions`)

## Test plan
- [ ] CI passes on this PR (the workflow itself uses these permissions)